### PR TITLE
allow only one . (dot) for scene headings

### DIFF
--- a/syntax/fountain.vim
+++ b/syntax/fountain.vim
@@ -32,7 +32,7 @@ syn region fountainHeader4 start="^\s*#### " end="$" contains=fountainBoneyard,f
 syn region fountainHeader5 start="^\s*##### " end="$" contains=fountainBoneyard,fountainNotes
 syn region fountainHeader6 start="^\s*###### " end="$" contains=fountainBoneyard,fountainNotes
 syn region fountainSynopses start="^\s*= " end="$" contains=fountainBoneyard,fountainNotes
-syn region fountainSceneHeading start="^\s*\(\.[^\.]\|INT\. \|EXT\. \|INT\./EXT\. \|INT/EXT\. \|INT \|EXT \|INT/EXT \|I/E \|int\. \|ext\. \|int\./ext\. \|int/ext\. \|int \|ext \|int/ext \|i/e \)" end="$" contains=fountainSceneNumber,fountainBoneyard,fountainNotes 
+syn region fountainSceneHeading start="^\s*\(\.[^\.]\|INT\. \|EXT\. \|INT\./EXT\. \|INT/EXT\. \|INT \|EXT \|INT/EXT \|I/E \|EST\. \|int\. \|ext\. \|int\./ext\. \|int/ext\. \|int \|ext \|int/ext \|i/e \|est\. \)" end="$" contains=fountainSceneNumber,fountainBoneyard,fountainNotes 
 syn region fountainBoneyard start="/\*" end="\*\/" contains=xLineContinue
 syn match xLineContinue "\\$" contained
 syn region fountainSceneNumber start="#" end="#" contained

--- a/syntax/fountain.vim
+++ b/syntax/fountain.vim
@@ -32,7 +32,7 @@ syn region fountainHeader4 start="^\s*#### " end="$" contains=fountainBoneyard,f
 syn region fountainHeader5 start="^\s*##### " end="$" contains=fountainBoneyard,fountainNotes
 syn region fountainHeader6 start="^\s*###### " end="$" contains=fountainBoneyard,fountainNotes
 syn region fountainSynopses start="^\s*= " end="$" contains=fountainBoneyard,fountainNotes
-syn region fountainSceneHeading start="^\s*\(\.[^.]\|INT\. \|EXT\. \|INT\./EXT\. \|INT/EXT\. \|INT \|EXT \|INT/EXT \|I/E \|int\. \|ext\. \|int\./ext\. \|int/ext\. \|int \|ext \|int/ext \|i/e \)" end="$" contains=fountainSceneNumber,fountainBoneyard,fountainNotes 
+syn region fountainSceneHeading start="^\s*\(\.[^\.]\|INT\. \|EXT\. \|INT\./EXT\. \|INT/EXT\. \|INT \|EXT \|INT/EXT \|I/E \|int\. \|ext\. \|int\./ext\. \|int/ext\. \|int \|ext \|int/ext \|i/e \)" end="$" contains=fountainSceneNumber,fountainBoneyard,fountainNotes 
 syn region fountainBoneyard start="/\*" end="\*\/" contains=xLineContinue
 syn match xLineContinue "\\$" contained
 syn region fountainSceneNumber start="#" end="#" contained

--- a/syntax/fountain.vim
+++ b/syntax/fountain.vim
@@ -32,7 +32,7 @@ syn region fountainHeader4 start="^\s*#### " end="$" contains=fountainBoneyard,f
 syn region fountainHeader5 start="^\s*##### " end="$" contains=fountainBoneyard,fountainNotes
 syn region fountainHeader6 start="^\s*###### " end="$" contains=fountainBoneyard,fountainNotes
 syn region fountainSynopses start="^\s*= " end="$" contains=fountainBoneyard,fountainNotes
-syn region fountainSceneHeading start="^\s*\(\.\|INT\. \|EXT\. \|INT\./EXT\. \|INT/EXT\. \|INT \|EXT \|INT/EXT \|I/E \|int\. \|ext\. \|int\./ext\. \|int/ext\. \|int \|ext \|int/ext \|i/e \)" end="$" contains=fountainSceneNumber,fountainBoneyard,fountainNotes 
+syn region fountainSceneHeading start="^\s*\(\.[^.]\|INT\. \|EXT\. \|INT\./EXT\. \|INT/EXT\. \|INT \|EXT \|INT/EXT \|I/E \|int\. \|ext\. \|int\./ext\. \|int/ext\. \|int \|ext \|int/ext \|i/e \)" end="$" contains=fountainSceneNumber,fountainBoneyard,fountainNotes 
 syn region fountainBoneyard start="/\*" end="\*\/" contains=xLineContinue
 syn match xLineContinue "\\$" contained
 syn region fountainSceneNumber start="#" end="#" contained


### PR DESCRIPTION
The syntax for scene headings states on https://fountain.io/syntax#section-slug

"Note that only a single leading period followed by an alphanumeric character will force a Scene Heading. This allows the writer to begin Action and Dialogue elements with ellipses without worry that they'll be interpreted as Scene Headings."

-- this is now fixed.