### PR TITLE
filetype setting, bugfix in existing highlighting and additional highlights and enhancements

### DIFF
--- a/README
+++ b/README
@@ -1,3 +1,9 @@
+This is a mirror of https://github.com/vim-scripts/fountain.vim, which is
+unmaintained. This fork has merged the two PRs on that repository and will
+accept additional PRs. 
+
+---
+
 This is a mirror of http://www.vim.org/scripts/script.php?script_id=3880
 
 Fountain is a plain text markup language for screenwriting.

--- a/ftdetect/fountain.vim
+++ b/ftdetect/fountain.vim
@@ -1,0 +1,1 @@
+au BufRead,BufNewFile *.fountain set filetype=fountain

--- a/syntax/fountain.vim
+++ b/syntax/fountain.vim
@@ -11,6 +11,7 @@ if exists("b:current_syntax")
 endif
 syn sync minlines=200
 
+syn match fountainAction "^\(\a\)*\s*.*$" contains=fountainBoneyard,fountainNotes
 syn match fountainSection1 "^\s*# \(\_[^#]\)" fold transparent contains=ALL
 syn region fountainTitlePage start="\%^\(.*\):" end="^$" contains=fountainBoneyard,fountainNotes
 syn match fountainCharacter "\(^\s*@\(.*\)\)\|\(^\(\L\)*$\)" 
@@ -33,25 +34,27 @@ syn region fountainHeader4 start="^\s*#### " end="$" contains=fountainBoneyard,f
 syn region fountainHeader5 start="^\s*##### " end="$" contains=fountainBoneyard,fountainNotes
 syn region fountainHeader6 start="^\s*###### " end="$" contains=fountainBoneyard,fountainNotes
 syn region fountainSynopses start="^\s*= " end="$" contains=fountainBoneyard,fountainNotes
-syn region fountainSceneHeading start="^\s*\(\.[^\. ]\|INT\. \|EXT\. \|INT\./EXT\. \|INT/EXT\. \|INT \|EXT \|INT/EXT \|I/E \|int\. \|ext\. \|int\./ext\. \|int/ext\. \|int \|ext \|int/ext \|i/e \)" end="$" contains=fountainSceneNumber,fountainBoneyard,fountainNotes 
+syn region fountainSceneHeading start="^\s*\(\.[^\. ]\|INT\. \|EXT\. \|INT\.\/EXT\. \|INT\/EXT\. \|INT \|EXT \|INT\/EXT \|I\/E \)\c" end="$" contains=fountainSceneNumber,fountainBoneyard,fountainNotes 
+syn region fountainAction matchgroup=fountainSceneHeading start="^\s*\(\.[^\. ]\|INT\. \|EXT\. \|INT\.\/EXT\. \|INT\/EXT\. \|INT \|EXT \|INT\/EXT \|I\/E \)\(.*\)$\n*\ze\a\c" end="\n\n" contains=fountainBoneyard,fountainNotes,fountainBold,fountainUnderlined,fountainItalic,fountainBoldItalic
 syn region fountainBoneyard start="/\*" end="\*\/" contains=xLineContinue
 syn match xLineContinue "\\$" contained
 syn region fountainSceneNumber start="#" end="#" contained
 
-hi def link fountainTitlePage		    title
-hi def link fountainSection1 				Underlined
+hi def link fountainTitlePage		    PreProc
+hi def link fountainSection1 			Underlined
 hi def link fountainSceneHeading	    title
+hi def link fountainAction              string
 hi def link fountainCharacter			identifier 
 hi def link fountainDialogue			statement
-hi def link fountainParenthetical		vimIsCommand
+hi def link fountainParenthetical		conditional
 hi def link fountainTransition			todo
-hi def link fountainLyric						normal
+hi def link fountainLyric				normal
 hi def link fountainTransitionForced	todo
 hi def link fountainCentered			character
-hi fountainUnderlined					gui=underline
-hi fountainItalic						gui=italic cterm=italic	
-hi fountainBold							gui=bold cterm=bold
-hi fountainBoldItalic					gui=bold,italic cterm=bold,italic	
+hi def fountainUnderlined					gui=underline
+hi def fountainItalic						gui=italic cterm=italic	
+hi def fountainBold							gui=bold cterm=bold
+hi def fountainBoldItalic					gui=bold,italic cterm=bold,italic	
 hi def link fountainPagebreak			conditional
 hi def link fountainActionForced		normal
 hi def link fountainNotes				comment
@@ -65,4 +68,36 @@ hi def link fountainHeader6				CursorLineNr
 hi def link fountainSynopses			number
 hi def link fountainSceneNumber			number	
 
+function! FountainFolds()
+  let thisline = getline(v:lnum)
+  let laterline = getline(v:lnum + 2)
+  if match(thisline, '^EXT') >= 0
+    return ">1"
+  elseif match(thisline, '^INT') >= 0
+    return ">1"
+	elseif match(thisline, '^Title:') >= 0
+    return ">1"
+  elseif match(thisline, '^\.[^.]') >= 0
+    return ">1"
+  elseif match(laterline, '^EXT') >= 0
+    return "<1"
+  elseif match(laterline, '^INT') >= 0
+    return "<1"
+  elseif match(laterline, '^Title:') >= 0
+    return "<1"
+  elseif match(laterline, '^\.[^.]') >= 0
+    return "<1"
+  else
+    return "="
+  endif
+endfunction
+
+setlocal foldmethod=expr
+setlocal foldexpr=FountainFolds()
+
+function! FountainFoldText()
+  let foldsize = (v:foldend-v:foldstart)
+  return getline(v:foldstart).' ('.foldsize.' lines)'
+endfunction
+setlocal foldtext=FountainFoldText()
 let b:current_syntax = "fountain"

--- a/syntax/fountain.vim
+++ b/syntax/fountain.vim
@@ -33,7 +33,7 @@ syn region fountainHeader4 start="^\s*#### " end="$" contains=fountainBoneyard,f
 syn region fountainHeader5 start="^\s*##### " end="$" contains=fountainBoneyard,fountainNotes
 syn region fountainHeader6 start="^\s*###### " end="$" contains=fountainBoneyard,fountainNotes
 syn region fountainSynopses start="^\s*= " end="$" contains=fountainBoneyard,fountainNotes
-syn region fountainSceneHeading start="^\s*\(\.\|INT\. \|EXT\. \|INT\./EXT\. \|INT/EXT\. \|INT \|EXT \|INT/EXT \|I/E \|int\. \|ext\. \|int\./ext\. \|int/ext\. \|int \|ext \|int/ext \|i/e \)" end="$" contains=fountainSceneNumber,fountainBoneyard,fountainNotes 
+syn region fountainSceneHeading start="^\s*\(\.[^\. ]\|INT\. \|EXT\. \|INT\./EXT\. \|INT/EXT\. \|INT \|EXT \|INT/EXT \|I/E \|int\. \|ext\. \|int\./ext\. \|int/ext\. \|int \|ext \|int/ext \|i/e \)" end="$" contains=fountainSceneNumber,fountainBoneyard,fountainNotes 
 syn region fountainBoneyard start="/\*" end="\*\/" contains=xLineContinue
 syn match xLineContinue "\\$" contained
 syn region fountainSceneNumber start="#" end="#" contained

--- a/syntax/fountain.vim
+++ b/syntax/fountain.vim
@@ -13,9 +13,10 @@ syn sync minlines=200
 
 syn match fountainSection1 "^\s*# \(\_[^#]\)" fold transparent contains=ALL
 syn region fountainTitlePage start="\%^\(.*\):" end="^$" contains=fountainBoneyard,fountainNotes
-syn match fountainCharacter "^\(\L\)*$" 
-syn region fountainDialogue matchgroup=fountainCharacter start="^\(\L\)*$" end="^\s*$" contains=fountainCharacter,fountainParenthetical,fountainBoneyard,fountainNotes,fountainEmphasis
+syn match fountainCharacter "\(^\s*@\(.*\)\)\|\(^\(\L\)*$\)" 
+syn region fountainDialogue matchgroup=fountainCharacter start="\(^\s*@\(.*\)\)\|\(^\(\L\)*$\)" end="^\s*$" contains=fountainCharacter,fountainParenthetical,fountainBoneyard,fountainNotes,fountainBold,fountainUnderlined,fountainItalic,fountainBoldItalic
 syn match fountainParenthetical "^\s*\((.*)\)$" contained contains=fountainBoneyard,fountainNotes
+syn match fountainLyric "^\s*\~\(.*\)$" contained contains=fountainBoneyard,fountainNotes
 syn match fountainTransition "^\(\L\)* TO:$" contains=fountainBoneyard,fountainNotes
 syn match fountainTransitionForced "^\s*>\(.*\)" contains=fountainBoneyard,fountainNotes
 syn match fountainCentered "^\s*>\(.*\)<" contains=fountainBoneyard,fountainNotes
@@ -38,27 +39,29 @@ syn match xLineContinue "\\$" contained
 syn region fountainSceneNumber start="#" end="#" contained
 
 hi def link fountainTitlePage		    title
+hi def link fountainSection1 				Underlined
 hi def link fountainSceneHeading	    title
 hi def link fountainCharacter			identifier 
 hi def link fountainDialogue			statement
-hi def link fountainParenthetical		function
+hi def link fountainParenthetical		vimIsCommand
 hi def link fountainTransition			todo
+hi def link fountainLyric						normal
 hi def link fountainTransitionForced	todo
 hi def link fountainCentered			character
 hi fountainUnderlined					gui=underline
 hi fountainItalic						gui=italic cterm=italic	
-hi fountainBold							gui=bold cterm=bold	
+hi fountainBold							gui=bold cterm=bold
 hi fountainBoldItalic					gui=bold,italic cterm=bold,italic	
 hi def link fountainPagebreak			conditional
 hi def link fountainActionForced		normal
 hi def link fountainNotes				comment
 hi def link fountainBoneyard			nontext	
-hi def link fountainHeader1				htmlH1	
-hi def link fountainHeader2				htmlH2	
-hi def link fountainHeader3				htmlH3	
-hi def link fountainHeader4				htmlH4	
-hi def link fountainHeader5				htmlH5	
-hi def link fountainHeader6				htmlH6	
+hi def link fountainHeader1				CursorLineNr	
+hi def link fountainHeader2				CursorLineNr	
+hi def link fountainHeader3				CursorLineNr	
+hi def link fountainHeader4				CursorLineNr	
+hi def link fountainHeader5				CursorLineNr	
+hi def link fountainHeader6				CursorLineNr	
 hi def link fountainSynopses			number
 hi def link fountainSceneNumber			number	
 


### PR DESCRIPTION
current fountain.vim does not correctly recognize scene headers in syntax highlighting.
this fixes that and adds a few other tweaks